### PR TITLE
Let rustfmt take care of wrapping comments

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -7,3 +7,5 @@ edition = "2021"
 match_block_trailing_comma = true
 tab_spaces = 2
 trailing_semicolon = false
+wrap_comments = true
+comment_width = 80


### PR DESCRIPTION
It turns out rustfmt can ensure a consistent comment length by applying automatic wrapping. Let's enable the functionality to get some more consistency into the code base and ensure that pull requests adhere to a basic standard in the process.