### PR TITLE
Warn on small set of useful lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,16 @@
 // Copyright (C) 2024 Daniel Mueller <deso@posteo.net>
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+//! A crate for interacting with [`debuginfod`][debuginfod] servers.
+//!
+//! [debuginfod]: https://sourceware.org/elfutils/Debuginfod.html
+
+#![warn(
+  missing_debug_implementations,
+  missing_docs,
+  clippy::absolute_paths,
+  rustdoc::broken_intra_doc_links
+)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "fs-cache")]


### PR DESCRIPTION
Enable warnings for a small set of useful lints to make sure that minor mishaps such as missing documentation of public items get caught early on.