### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock


### PR DESCRIPTION
Exclude cargo's lockfile as this is a library and typically it is preferred to not commit it to the repo.