### PR TITLE
Add `Response` struct and return it in `Client::fetch_debug_info()`

### DIFF
--- a/src/caching_client.rs
+++ b/src/caching_client.rs
@@ -89,7 +89,7 @@ impl CachingClient {
       return Ok(Some(path))
     }
 
-    let mut debug_info = if let Some(debug_info) = self.client.fetch_debug_info(build_id)? {
+    let mut response = if let Some(debug_info) = self.client.fetch_debug_info(build_id)? {
       debug_info
     } else {
       return Ok(None)
@@ -100,8 +100,8 @@ impl CachingClient {
     // `persist` below won't work and we cannot guarantee atomicity.
     let mut tempfile =
       NamedTempFile::new_in(&self.cache_dir).context("failed to create temporary file")?;
-    let _count =
-      copy(&mut debug_info, &mut tempfile).context("failed to write debug info to file system")?;
+    let _count = copy(&mut response.data, &mut tempfile)
+      .context("failed to write debug info to file system")?;
 
     // SANITY: Our path is guaranteed to always have a parent.
     let dir = path.parent().unwrap();


### PR DESCRIPTION
Which allows for a richer set of informatiomn to be passed to the caller beyond the actual debug information reader. The first additional field is the debuginfod server that returned the response. This is very helpful for systems that want to store the source of said debug information. This is typicall used for later debugging, re-downloading the debug information, if needed, etc.

Test Plan
=========

Adapted the tests.