### PR TITLE
Fix formatting of build ID in Client::fetch_debug_info

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -135,7 +135,7 @@ impl Client {
     }
 
     if let Some(err) = server_err.or(issue_err) {
-      Err(err).context("failed to fetch debug info for build ID `{build_id}`")
+      Err(err).with_context(|| format!("failed to fetch debug info for build ID `{build_id}`"))
     } else {
       Ok(None)
     }


### PR DESCRIPTION
Client::fetch_debug_info() intends to format the build ID to include it in the error reported, but was not using the correct incantation for doing so. Fix it up.

Closes: #11

Reported-by: Javier Honduvilla Coto <javierhonduco@gmail.com>