### PR TITLE
Fix formatting of URL in Client::fetch_debug_info

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -126,7 +126,7 @@ impl Client {
       let result = self
         .client
         .execute(Request::new(Method::GET, url.clone()))
-        .context("failed to issue request to `{url}`");
+        .with_context(|| format!("failed to issue request to `{url}`"));
       let response = match result {
         Ok(response) => response,
         Err(err) => {


### PR DESCRIPTION
Similar to what we did in commit 5890b9356ddb ("Fix formatting of build ID in Client::fetch_debug_info"), make sure to format the URL correctly on error return.

Reported-by: Javier Honduvilla Coto <javierhonduco@gmail.com>