### PR TITLE
Add CHANGELOG for #10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Unreleased
 ----------
 - Introduced `BuildId` enum and adjusted `fetch_debug_info` methods to
   work with it
+- Introduced `Response` type to include additional meta data from
+  `Client::fetch_debug_info` method
 
 
 0.1.1

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,12 +30,9 @@ pub struct Response<'url, R> {
 }
 
 /// Creates a new `DebugInfoResponse`.
-impl<'debug_info_response, R: Read> Response<'debug_info_response, R> {
-  fn new(data: R, debug_infod_url: &'debug_info_response str) -> Self {
-    Response {
-      data,
-      server_url: debug_infod_url,
-    }
+impl<'url, R: Read> Response<'url, R> {
+  fn new(data: R, server_url: &'url str) -> Self {
+    Self { data, server_url }
   }
 }
 


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #10, which introduced a Response type to the Client::fetch_debug_info method. Also fix up some minor cosmetical issues overlooked earlier.