### PR TITLE
Export Response type from crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+- Exported `Response` type from rate to make it nameable in user code
+
+
 0.2.0
 -----
 - Introduced `BuildId` enum and adjusted `fetch_debug_info` methods to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub use buildid::BuildId;
 #[cfg_attr(docsrs, doc(cfg(feature = "fs-cache")))]
 pub use caching_client::CachingClient;
 pub use client::Client;
+pub use client::Response;
 
 
 #[cfg(feature = "tracing")]


### PR DESCRIPTION
To improve usability, export the Response type from the crate. This way, users can actually name it in their code.