### PR TITLE
Build reqwest with rustls rather than openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tracing = ["dep:tracing"]
 [dependencies]
 anyhow = "1.0.68"
 dirs = {version = "6.0", default-features = false, optional = true}
-reqwest = {version = "0.12.4", features = ["blocking", "gzip"]}
+reqwest = {version = "0.12.4", default-features = false, features = ["blocking", "gzip", "rustls-tls"]}
 tempfile = {version = "3.10.1", default-features = false, optional = true}
 tracing = {version = "0.1.27", default-features = false, optional = true}
 
@@ -49,8 +49,6 @@ test-fork = {version = "0.1.3", default-features = false}
 # dependency specifications themselves.
 # error: cannot find macro `log_enabled` in this scope
 _log_unused = { package = "log", version = "0.4.6" }
-# error: pasting "RUST_VERSION_OPENSSL_" and "(" does not give a valid preprocessing token
-_openssl_unused = {package = "openssl", version = "0.10.35"}
 # error[E0277]: the trait bound `Version: From<({integer}, {integer}, {integer})>` is not satisfied
 _rustc_version_unused = { package = "rustc_version", version = "0.2.2" }
 


### PR DESCRIPTION
By default request's TLS stack depends on openssl which requires the native library to be linked against. Besides the fact that rustls is written in a memory safe language, as it's pure Rust, cross compilation is way easier.

See `cargo tree`'s output:

```
│   ├── debuginfod v0.2.0
│   │   ├── anyhow v1.0.97
│   │   ├── dirs v5.0.1
│   │   │   └── dirs-sys v0.4.1
│   │   │       ├── libc v0.2.171
│   │   │       └── option-ext v0.2.0
│   │   ├── reqwest v0.12.15
│   │   │   ├── async-compression v0.4.22
│   │   │   │   ├── flate2 v1.1.0 (*)
│   │   │   │   ├── futures-core v0.3.31
│   │   │   │   ├── memchr v2.7.4
│   │   │   │   ├── pin-project-lite v0.2.16
│   │   │   │   └── tokio v1.44.1 (*)
│   │   │   ├── base64 v0.22.1
│   │   │   ├── bytes v1.10.1
│   │   │   ├── encoding_rs v0.8.35 (*)
│   │   │   ├── futures-channel v0.3.31 (*)
│   │   │   ├── futures-core v0.3.31
│   │   │   ├── futures-util v0.3.31 (*)
│   │   │   ├── h2 v0.4.8 (*)
│   │   │   ├── http v1.3.1 (*)
│   │   │   ├── http-body v1.0.1 (*)
│   │   │   ├── http-body-util v0.1.3 (*)
│   │   │   ├── hyper v1.6.0 (*)
│   │   │   ├── hyper-tls v0.6.0
│   │   │   │   ├── bytes v1.10.1
│   │   │   │   ├── http-body-util v0.1.3 (*)
│   │   │   │   ├── hyper v1.6.0 (*)
│   │   │   │   ├── hyper-util v0.1.10 (*)
│   │   │   │   ├── native-tls v0.2.14
│   │   │   │   │   ├── log v0.4.27
│   │   │   │   │   ├── openssl v0.10.71
│   │   │   │   │   │   ├── bitflags v2.9.0
│   │   │   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   │   │   ├── foreign-types v0.3.2
│   │   │   │   │   │   │   └── foreign-types-shared v0.1.1
│   │   │   │   │   │   ├── libc v0.2.171
│   │   │   │   │   │   ├── once_cell v1.21.2
│   │   │   │   │   │   ├── openssl-macros v0.1.1 (proc-macro)
│   │   │   │   │   │   │   ├── proc-macro2 v1.0.94 (*)
│   │   │   │   │   │   │   ├── quote v1.0.40 (*)
│   │   │   │   │   │   │   └── syn v2.0.100 (*)
│   │   │   │   │   │   └── openssl-sys v0.9.106
│   │   │   │   │   │       └── libc v0.2.171
│   │   │   │   │   │       [build-dependencies]
│   │   │   │   │   │       ├── cc v1.2.17 (*)
│   │   │   │   │   │       ├── pkg-config v0.3.32
│   │   │   │   │   │       └── vcpkg v0.2.15
│   │   │   │   │   ├── openssl-probe v0.1.6
│   │   │   │   │   └── openssl-sys v0.9.106 (*)
```