### PR TITLE
Fix type in Client::new() documentation

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -51,8 +51,7 @@ impl Client {
   ///
   /// The provided `base_urls` is a list of URLs in decreasing order of
   /// importance. `Ok(None)` will be returned if this list is empty. If
-  /// any of the variables could not be parsed, an error will be
-  /// emitted.
+  /// any of the URLs could not be parsed, an error will be emitted.
   pub fn new<'url, U>(base_urls: U) -> Result<Option<Self>>
   where
     U: IntoIterator<Item = &'url str>,


### PR DESCRIPTION
The constructor does not parse any "variables", it parses URLs. Fix the wording.