### PR TITLE
HTTP client trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,18 +28,22 @@ A crate for interacting with debuginfod servers.
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["fs-cache"]
+default = ["fs-cache", "reqwest"]
 # Enable support for file system based caching.
 fs-cache = ["dep:dirs", "dep:tempfile"]
+# Provide an HTTP client implementation based on reqwest.
+reqwest = ["dep:reqwest"]
 # Enable support for emitting traces.
 tracing = ["dep:tracing"]
 
 [dependencies]
 anyhow = "1.0.68"
 dirs = {version = "6.0", default-features = false, optional = true}
-reqwest = {version = "0.12.4", default-features = false, features = ["blocking", "gzip", "rustls-tls"]}
+http = "1.3.1"
+reqwest = {version = "0.12.4", default-features = false, features = ["blocking", "gzip", "rustls-tls"], optional = true}
 tempfile = {version = "3.10.1", default-features = false, optional = true}
 tracing = {version = "0.1.27", default-features = false, optional = true}
+url = "2.5.7"
 
 [dev-dependencies]
 blazesym = {version = "0.2", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tracing = {version = "0.1.27", default-features = false, optional = true}
 
 [dev-dependencies]
 blazesym = {version = "0.2", default-features = false}
+tempfile = {version = "3.10.1", default-features = false}
 test-fork = {version = "0.1.3", default-features = false}
 # A set of unused dependencies that we require to force correct minimum versions
 # of transitive dependencies, for cases where our dependencies have incorrect

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Arvid Norlander <VorpalBlade@users.noreply.github.com>
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+use std::error::Error;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
+use std::io::Read;
+
+use http::StatusCode;
+
+/// An error that occurred while performing an HTTP request.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum HttpClientError {
+  /// The server responded with a non-success status code.
+  StatusCode(StatusCode),
+  /// The provided URL was not a well formed URL.
+  InvalidUrl(Box<dyn Error + Send + Sync>),
+  /// Some other error occurred.
+  Other(Box<dyn Error + Send + Sync>),
+}
+
+impl Display for HttpClientError {
+  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+    match self {
+      Self::StatusCode(code) => {
+        write!(
+          f,
+          "HTTP request failed with status code {code} {}",
+          code.canonical_reason().unwrap_or("")
+        )
+      },
+      Self::Other(err) => write!(f, "HTTP client error: {err}"),
+      Self::InvalidUrl(error) => {
+        write!(f, "Invalid URL: {error}")
+      },
+    }
+  }
+}
+
+impl Error for HttpClientError {
+  fn source(&self) -> Option<&(dyn Error + 'static)> {
+    match self {
+      Self::StatusCode(_) => None,
+      Self::InvalidUrl(err) | Self::Other(err) => Some(&**err),
+    }
+  }
+}
+
+/// A trait representing HTTP client capable of performing blocking GET
+/// requests, used to download debug information from `debuginfod` servers.
+pub trait HttpClient: Debug {
+  /// Perform a blocking HTTP GET request to the specified URL.
+  fn get(&self, url: &str) -> Result<Box<dyn Read>, HttpClientError>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ mod buildid;
 #[cfg(feature = "fs-cache")]
 mod caching_client;
 mod client;
+mod http_client;
+#[cfg(feature = "reqwest")]
+mod reqwest_client;
 mod util;
 
 pub use buildid::BuildId;
@@ -24,7 +27,10 @@ pub use buildid::BuildId;
 #[cfg_attr(docsrs, doc(cfg(feature = "fs-cache")))]
 pub use caching_client::CachingClient;
 pub use client::Client;
+pub use client::ClientBuilder;
 pub use client::Response;
+pub use http_client::HttpClient;
+pub use http_client::HttpClientError;
 
 
 #[cfg(feature = "tracing")]

--- a/src/reqwest_client.rs
+++ b/src/reqwest_client.rs
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 Arvid Norlander <VorpalBlade@users.noreply.github.com>
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+use std::io::Read;
+
+use http::Method;
+use reqwest::blocking::Client as BlockingClient;
+use reqwest::blocking::Request;
+
+use crate::http_client::HttpClient;
+use crate::http_client::HttpClientError;
+
+/// Implements the `HttpClient` trait using the `reqwest` crate.
+impl HttpClient for BlockingClient {
+  /// Perform a blocking HTTP GET request to the specified URL.
+  fn get(&self, url: &str) -> Result<Box<dyn Read>, HttpClientError> {
+    let resp = self
+      .execute(Request::new(
+        Method::GET,
+        url
+          .try_into()
+          .map_err(|err| HttpClientError::InvalidUrl(Box::new(err)))?,
+      ))
+      .map_err(|err| HttpClientError::Other(Box::new(err)))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+      return Err(HttpClientError::StatusCode(status));
+    }
+
+    Ok(Box::new(resp))
+  }
+}


### PR DESCRIPTION
This is the sync-only version of this, with no generics for the end user. That does lead to additional boxing of the results (`Box<dyn Read>`).

As for async I will need to tinker about more.